### PR TITLE
perf: use -Ofast at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 ARCH=`uname -m`
 
 all:
-	$(CC) -c -Wall -static -fpic -o ./src/match.o ./src/match.c
+	$(CC) -Ofast -c -Wall -static -fpic -o ./src/match.o ./src/match.c
 	$(CC) -shared -o ./static/libfzy-$(OS)-$(ARCH).so ./src/match.o
 
 


### PR DESCRIPTION
I know this might sound dumb, but it actually improves performance by quite a factor.

Some further improvements could be made on the algorithm itself, i.e. :

- The only search mode is case-insensitive, maybe we could specialize the code for that use case
- In the original repo, it is said that optimizing a `strpbrk`-ish function may help by a fair
  amount, I think we should dig into this direction too.
