### PR TITLE
remove need for GCC from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # romgrk, 2020-11-02 21:58
 #
 
-CC=gcc
+CC ?= gcc
 OS=$(shell uname | tr A-Z a-z)
 ifeq ($(findstring mingw,$(OS)), mingw)
     OS='windows'


### PR DESCRIPTION
On some platforms gcc is not available, to fix this issue let's use the
cc program which is the system c compiler.

The make variable is now assigned with the '?=' operator, this causes
make to only set the variable if it is not already defined e.g.
`CC=gcc make`

This closes #6.