### PR TITLE
Support x64 and arm64 on darwin.

### DIFF
--- a/lua/native.lua
+++ b/lua/native.lua
@@ -13,7 +13,7 @@ local os_aliases = {
 
 local arch_aliases = {
   ['x64'] = 'x86_64',
-  ['arm64'] = 'aarch64',
+  --['arm64'] = 'aarch64',
 }
 
 local ffi = require'ffi'


### PR DESCRIPTION
Hi, 
On my m1 Mac mini , the arch name is __arm64__, not __aarch64__.
And I also test it on 2019 MacBook Pro(x86_64).
It works well for both arch.

Please check it out.

Thank you.