### PR TITLE
Add scores to filter/filter_many and fix positions_many

### DIFF
--- a/lua/native.lua
+++ b/lua/native.lua
@@ -76,6 +76,16 @@ local function positions_to_lua_many(numbers, length, n)
   return result
 end
 
+-- @param scores - the C positions object
+-- @param length - length of scores
+-- @returns - lua array of scores, 1-indexed
+local function scores_to_lua_many(scores, length)
+  local result = {}
+  for i = 0, length - 1, 1  do
+    table.insert(result, scores[i] + 1)
+  end
+  return result
+end
 
 -- Constants
 
@@ -123,7 +133,7 @@ function fzy.positions_many(needle, haystacks)
 
   local haystacks_arg = ffi.new("const char*[" .. (length + 1) .. "]", haystacks)
 
-  local score = native.match_positions_many(
+  native.match_positions_many(
     needle,
     haystacks_arg,
     length,
@@ -131,7 +141,7 @@ function fzy.positions_many(needle, haystacks)
     positions,
     is_case_sensitive)
 
-  return positions_to_lua_many(positions, length, n), score
+  return positions_to_lua_many(positions, length, n), scores_to_lua_many(scores, length)
 end
 
 
@@ -161,8 +171,8 @@ function fzy.filter(needle, lines)
   for i = 1, #lines do
     local line = lines[i]
     if native.has_match(needle, line, false) == 1 then
-      local positions = fzy.positions(needle, line)
-      table.insert(results, { line, positions })
+      local positions, score = fzy.positions(needle, line)
+      table.insert(results, { line, positions, score })
     end
   end
   return results
@@ -177,8 +187,8 @@ function fzy.filter_many(needle, lines)
       table.insert(filtered_lines, line)
     end
   end
-  local positions = fzy.positions_many(needle, filtered_lines)
-  return positions
+
+  return fzy.positions_many(needle, filtered_lines)
 end
 
 return fzy

--- a/lua/original.lua
+++ b/lua/original.lua
@@ -201,8 +201,8 @@ function fzy.filter(needle, lines)
   for i = 1, #lines do
     local line = lines[i]
     if fzy.has_match(needle, line) then
-      local positions = fzy.positions(needle, line)
-      table.insert(results, { line, positions })
+      local positions, score = fzy.positions(needle, line)
+      table.insert(results, { line, positions, score })
     end
   end
   return results


### PR DESCRIPTION
When using `fzy_lua_native` in a project that I'm working on I came across several inconsistencies and some missing functionality.

1. The `filter` result table did not include the `scores` even though these are already calculated by `.positions` Having to recalculate them in my project hampers performance unnecessarily.
2. The `postitions_many` object always returned a `nil` score, instead I'd want a table of scores similar to the `postitions` table.

I addressed these pain points in this PR by:

- Including score (returned by `positions`) in the
  `filter` result table.
- Adding a new function `scores_to_lua_many` which converts the `scores` C object to a
  lua table.
- Remove useless assignment `score = match_positions_many` as it
  always returned nil.
- Return table with scores in `positions_many` and surface it in
  `filter_many`