### PR TITLE
Allow require('fzy-lua-native')

### DIFF
--- a/lua/fzy-lua-native.lua
+++ b/lua/fzy-lua-native.lua
@@ -1,0 +1,1 @@
+return require('.init')


### PR DESCRIPTION
Currently to use `fzy-lua-native` as a standalone Lua plugin (e.g. from `Plug 'romgrk/fzy-lua-native'`), we have to use `require('init')`, which might be problematic when there are namespace clashes.

This PR adds `fzy-lua-native.lua` which simply proxies to `init.lua` so users can use `require('fzy-lua-native')`.