### PR TITLE
fix: Relative module name requires are not correct

### DIFF
--- a/lua/fzy-lua-native.lua
+++ b/lua/fzy-lua-native.lua
@@ -1,1 +1,1 @@
-return require('.init')
+return require('init')


### PR DESCRIPTION
`lazy.nvim` clean up some `rtp` path for faster startup, causing this plugin not able to load in.