### PR TITLE
Make: do not overwrite existing shared objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,14 @@ ifeq ($(ARCH), aarch64)
 ARCH='arm64'
 endif
 
-all:
-	echo $(ARCH)
-	$(CC) $(CFLAGS) -Ofast -c -Wall -static -fpic -o ./src/match.o ./src/match.c
-	$(CC) $(CFLAGS) -shared -o ./static/libfzy-$(OS)-$(ARCH).so ./src/match.o
+all: ./static/libfzy-$(OS)-$(ARCH).so
+
+./static/libfzy-$(OS)-$(ARCH).so: ./src/match.c
+	$(CC) $(CFLAGS) -Ofast -c -Wall -static -fpic -o ./src/match.o $<
+	$(CC) $(CFLAGS) -shared -o $@ ./src/match.o
+
+clean:
+	rm -f **/*.o
 
 
 # vim:ft=make


### PR DESCRIPTION
This solution keeps the *.so files, and does not require the user to update anything (i.e. remove the `build = "make"` part of their config). If the os-arch combination does not exist. `make` will happily build it. If you ever wish to overwrite the already existing *.so file, either remove it manually first, or run `make -B` (always make). I think this is the 

If a user runs make and a shared object for their os and arch already exists, don't overwrite it. This prevents local git changes, which can hinder plugin managers like Lazy.nvim.

This commit also adds a `clean` target to remove the *.o files.

Caveats:
- The *.c -> *.o step can't be separated in its own step, because this would cause make to build the *.so file due to the absence of the *.o file.

Closes #28.